### PR TITLE
Enhance participant display with improved styling and API tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -21,8 +21,8 @@ document.addEventListener("DOMContentLoaded", () => {
         const spotsLeft = details.max_participants - details.participants.length;
 
         const participantsHtml = details.participants && details.participants.length
-          ? `<div class="participants"><strong>Participants:</strong><ul class="participants-list">${details.participants.map(p => `<li class="participant-item">${p}<span class="delete-btn" data-email="${p}">✖</span></li>`).join("")}</ul></div>`
-          : `<div class="participants"><strong>Participants:</strong><p class="no-participants">No participants yet.</p></div>`;
+          ? `<div class="participants"><strong>Participants</strong><ul class="participants-grid">${details.participants.map(p => `<li class="participant-pill"><span class="participant-name">${p}</span><button class="remove-btn" data-email="${p}" aria-label="Remove ${p}">🗑️</button></li>`).join("")}</ul></div>`
+          : `<div class="participants"><strong>Participants</strong><p class="no-participants">No participants yet.</p></div>`;
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
@@ -34,17 +34,21 @@ document.addEventListener("DOMContentLoaded", () => {
 
         activitiesList.appendChild(activityCard);
 
-        // Attach delete handlers for this card
-        activityCard.querySelectorAll('.delete-btn').forEach(btn => {
-          btn.addEventListener('click', async () => {
+        // Attach remove handlers (trash button) for this card
+        activityCard.querySelectorAll('.remove-btn').forEach(btn => {
+          btn.addEventListener('click', async (e) => {
+            e.stopPropagation();
             const email = btn.dataset.email;
+            if (!confirm(`Remove ${email} from ${name}?`)) return;
             try {
               const res = await fetch(
                 `/activities/${encodeURIComponent(name)}/signup?email=${encodeURIComponent(email)}`,
                 { method: 'DELETE' }
               );
               if (res.ok) {
-                // refresh list to update availability and participants
+                // visually indicate removal then refresh
+                const pill = btn.closest('.participant-pill');
+                if (pill) pill.style.opacity = '0.5';
                 fetchActivities();
               } else {
                 const err = await res.json();

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -75,53 +75,58 @@ section h3 {
 }
 
 .participants {
-  margin-top: 10px;
-  padding: 10px;
-  background-color: #f0f4ff;
-  border: 1px solid #d0d8f0;
-  border-radius: 6px;
+  margin-top: 12px;
+  padding: 12px;
+  background: linear-gradient(180deg,#f7f9ff,#eef4ff);
+  border: 1px solid #d7e0fb;
+  border-radius: 8px;
 }
 
 .participants strong {
   display: block;
   font-size: 15px;
-  margin-bottom: 6px;
-  color: #1a237e;
+  margin-bottom: 8px;
+  color: #0d1b6b;
 }
 
-.participants-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  color: #444;
-}
-
-.participant-item {
+.participants-grid {
   display: flex;
-  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
   align-items: center;
-  padding: 6px 8px;
-  font-size: 14px;
-  background: #ffffff;
-  border: 1px solid #e0e4f1;
-  border-radius: 4px;
-  margin-bottom: 6px;
-  transition: background-color 0.15s;
 }
 
-.participant-item:hover {
-  background-color: #eef2ff;
+.participant-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: #fff;
+  border: 1px solid #e6ecff;
+  border-radius: 999px;
+  font-size: 13px;
+  color: #24314a;
+  box-shadow: 0 1px 2px rgba(16,24,40,0.04);
 }
 
-.delete-btn {
-  cursor: pointer;
+.participant-name {
+  font-weight: 500;
+}
+
+.remove-btn {
+  appearance: none;
+  border: none;
+  background: transparent;
   color: #c62828;
-  font-weight: bold;
-  margin-left: 10px;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0;
+  line-height: 1;
 }
 
-.delete-btn:hover {
-  color: #e53935;
+.remove-btn:hover {
+  color: #b71c1c;
+  transform: scale(1.05);
 }
 
 .no-participants {

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -76,11 +76,22 @@ section h3 {
 
 .participants {
   margin-top: 10px;
+  padding: 10px;
+  background-color: #f0f4ff;
+  border: 1px solid #d0d8f0;
+  border-radius: 6px;
+}
+
+.participants strong {
+  display: block;
+  font-size: 15px;
+  margin-bottom: 6px;
+  color: #1a237e;
 }
 
 .participants-list {
   list-style: none;
-  margin: 8px 0 0 0;
+  margin: 0;
   padding: 0;
   color: #444;
 }
@@ -89,11 +100,17 @@ section h3 {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 4px 6px;
+  padding: 6px 8px;
   font-size: 14px;
-  background: linear-gradient(90deg, rgba(250,250,250,1) 0%, rgba(245,245,255,1) 100%);
-  border-radius: 3px;
+  background: #ffffff;
+  border: 1px solid #e0e4f1;
+  border-radius: 4px;
   margin-bottom: 6px;
+  transition: background-color 0.15s;
+}
+
+.participant-item:hover {
+  background-color: #eef2ff;
 }
 
 .delete-btn {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,68 @@
+import copy
+import pytest
+from fastapi.testclient import TestClient
+import src.app as app_module
+
+@pytest.fixture(autouse=True)
+def activities_backup():
+    # Arrange: snapshot the in-memory activities and restore after each test
+    backup = copy.deepcopy(app_module.activities)
+    yield
+    app_module.activities.clear()
+    app_module.activities.update(backup)
+
+@pytest.fixture
+def client():
+    with TestClient(app_module.app) as c:
+        yield c
+
+
+def test_get_activities(client):
+    # Arrange: none
+    # Act
+    resp = client.get("/activities")
+    # Assert
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, dict)
+    assert "Chess Club" in data
+
+
+def test_signup_and_prevent_duplicate(client):
+    # Arrange
+    activity = "Chess Club"
+    email = "testuser@example.com"
+
+    # Act: sign up
+    resp = client.post(f"/activities/{activity}/signup", params={"email": email})
+    # Assert
+    assert resp.status_code == 200
+    assert email in app_module.activities[activity]["participants"]
+
+    # Act: duplicate signup
+    resp_dup = client.post(f"/activities/{activity}/signup", params={"email": email})
+    # Assert duplicate rejected
+    assert resp_dup.status_code == 400
+
+
+def test_remove_participant(client):
+    # Arrange
+    activity = "Chess Club"
+    existing = app_module.activities[activity]["participants"][0]
+
+    # Act
+    resp = client.delete(f"/activities/{activity}/signup", params={"email": existing})
+    # Assert
+    assert resp.status_code == 200
+    assert existing not in app_module.activities[activity]["participants"]
+
+
+def test_remove_nonexistent_returns_404(client):
+    # Arrange
+    activity = "Chess Club"
+    nonmember = "ghost@example.com"
+
+    # Act
+    resp = client.delete(f"/activities/{activity}/signup", params={"email": nonmember})
+    # Assert
+    assert resp.status_code == 404


### PR DESCRIPTION
Title: Add participants UI + remove endpoint, polish styles, and tests

Summary
Adds a prettier participants view with per-user remove buttons, a backend endpoint to unregister participants, signup validation, and an AAA-pattern test suite. Also adds pytest to dependencies.

What changed

[app.js](https://fluffy-parakeet-g46jx644vr63vr4j.github.dev/): renders participants as pill items, adds a trash/remove button with confirmation, and refreshes the activity list after signups/removals.
[styles.css](https://fluffy-parakeet-g46jx644vr63vr4j.github.dev/): new pill-style participants UI and refined remove-button styling.
[app.py](https://fluffy-parakeet-g46jx644vr63vr4j.github.dev/): added DELETE /activities/{activity_name}/signup to remove participants; signup already blocks duplicate registrations.
[test_api.py](https://fluffy-parakeet-g46jx644vr63vr4j.github.dev/): new pytest tests (Arrange-Act-Assert) that snapshot & restore the in-memory [activities](https://fluffy-parakeet-g46jx644vr63vr4j.github.dev/) fixture between tests.
[requirements.txt](https://fluffy-parakeet-g46jx644vr63vr4j.github.dev/): added pytest.
Behavioral notes

UI updates immediately after sign-up/removal (no manual page reload).
Removing a participant requires confirmation and calls the new DELETE endpoint.
Duplicate signups return HTTP 400 (unchanged behavior from earlier validation).
How to test

Run server and open the UI:
Manual UI checks: sign up a user, confirm the participant pill appears; click trash to remove and confirm it disappears.
Run automated tests:
Suggested reviewers

Backend: API/endpoint and data safety
Frontend: UI/UX and styling